### PR TITLE
Feature/mlme associate

### DIFF
--- a/include/net/cfg802154.h
+++ b/include/net/cfg802154.h
@@ -74,9 +74,6 @@ struct cfg802154_ops {
 	int	(*ed_scan)(struct wpan_phy *wpan_phy, struct wpan_dev *wpan_dev,
 			u8 page, u32 scan_channels, u8 *level, size_t nlevel,
 			u8 duration );
-	int	(*assoc_req)(struct wpan_phy *wpan_phy, struct wpan_dev *wpan_dev,
-				u8 addr_mode, u16 coord_pan_id, u64 coord_addr,
-				u8 capability_information );
 	int	(*register_assoc_req_listener)(struct wpan_phy *wpan_phy,
 				struct wpan_dev *wpan_dev,
 				void (*callback)( struct sk_buff *, void *), void *arg);

--- a/net/ieee802154/nl802154.c
+++ b/net/ieee802154/nl802154.c
@@ -515,7 +515,6 @@ static int nl802154_send_wpan_phy(struct cfg802154_registered_device *rdev,
 	CMD(set_max_frame_retries, SET_MAX_FRAME_RETRIES);
 	CMD(set_lbt_mode, SET_LBT_MODE);
 	CMD(ed_scan, ED_SCAN_REQ);
-	CMD(assoc_req, ASSOC_REQ);
 
 	if (rdev->wpan_phy.flags & WPAN_PHY_FLAG_TXPOWER)
 		CMD(set_tx_power, SET_TX_POWER);
@@ -1426,7 +1425,8 @@ nl802154_assoc_send_empty_data_req(struct wpan_phy *wpan_phy, struct wpan_dev *w
 	memset( &source_addr, 0, sizeof( source_addr ) );
 	memset( &dst_addr, 0, sizeof( dst_addr ) );
 
-	hlen = 18;
+	hlen = 1 + 2 + 1 + 8 + 2; // Packet Length + Frame Control + Sequence Number + Extended Source Addr for Association Request + Destination PAN ID
+	hlen += IEEE802154_ADDR_LONG == addr_mode ? 8 : 2; // Extended or Short Destination address
 	tlen = wpan_dev->netdev->needed_tailroom;
 	size = 1; //Todo: Replace magic number. Comes from ieee std 802154 "Association Request Frame Format" with a define
 
@@ -1480,6 +1480,111 @@ nl802154_assoc_send_empty_data_req(struct wpan_phy *wpan_phy, struct wpan_dev *w
 	if( 0 == r) {
 		goto out;
 	}
+
+error:
+	kfree_skb(skb);
+out:
+	return r;
+}
+
+static int
+nl802154_assoc_send_assoc_req(struct wpan_phy *wpan_phy, struct wpan_dev *wpan_dev,
+		u8 addr_mode, u16 coord_pan_id, u64 coord_addr,
+		u8 capability_information ){
+
+	int r;
+
+	struct sk_buff *skb;
+	struct ieee802154_mac_cb *cb;
+	int hlen, tlen, size;
+	struct ieee802154_addr dst_addr, source_addr;
+	unsigned char *data;
+	u64 src_addr;
+
+	struct net_device *netdev;
+	struct device *logdev;
+
+	netdev = wpan_dev->netdev;
+	logdev = &netdev->dev;
+
+	src_addr = -1;
+
+	memset( &source_addr, 0, sizeof( source_addr ) );
+	memset( &dst_addr, 0, sizeof( dst_addr ) );
+
+	//Create beacon frame / payload
+	hlen = 1 + 2 + 1 + 8 + 2 + 2; // Packet Length + Frame Control + Sequence Number + Extended Source Addr for Association Request + Source PAN ID + Dest PAN ID
+	hlen += IEEE802154_ADDR_LONG == addr_mode ? 8 : 2; // Extended or Short Destination address
+	tlen = wpan_dev->netdev->needed_tailroom;
+	size = 2; //Todo: Replace magic number. Comes from ieee std 802154 "Association Request Frame Format" with a define
+
+	dev_dbg( logdev, "The skb lengths used are hlen: %d, tlen %d, and size %d\n", hlen, tlen, size);
+	dev_dbg( logdev, "Address of the netdev device structure: %p\n", wpan_dev->netdev );
+	//dev_dbg( logdev, "Address of ieee802154_local * local from wpan_phy_priv: %p\n", local );
+
+	skb = alloc_skb( hlen + tlen + size, GFP_KERNEL );
+	if (!skb){
+		r = -ENOMEM;
+		goto error;
+	}
+
+	skb_reserve(skb, hlen);
+
+	skb_reset_network_header(skb);
+
+	data = skb_put(skb, size);
+
+	source_addr.mode = IEEE802154_ADDR_LONG;
+	source_addr.pan_id = IEEE802154_PANID_BROADCAST;
+	source_addr.extended_addr = src_addr;
+
+	dst_addr.mode = addr_mode;
+	dst_addr.pan_id = coord_pan_id;
+
+	if ( IEEE802154_ADDR_SHORT == addr_mode ){
+		dst_addr.short_addr = (__le16)coord_addr;
+	} else {
+		dst_addr.extended_addr = coord_addr;
+	}
+
+	cb = mac_cb_init(skb);
+	cb->type = IEEE802154_FC_TYPE_MAC_CMD;
+	cb->ackreq = true;
+
+	cb->secen = false;
+	cb->secen_override = false;
+	cb->seclevel = 0;
+
+	cb->source = source_addr;
+	cb->dest = dst_addr;
+
+	//No security fields in yet.
+
+	dev_dbg( logdev, "DSN value in wpan_dev: %p\n", &wpan_dev->dsn);
+
+	dev_dbg( logdev, "Dest addr: 0x%04x\n", dst_addr.short_addr );
+	dev_dbg( logdev, "Dest addr long: 0x%016" PRIx64 "\n", dst_addr.extended_addr );
+	dev_dbg( logdev, "Src addr: 0x%04x\n", source_addr.short_addr );
+	dev_dbg( logdev, "Src addr long: 0x%016" PRIx64 "\n", source_addr.extended_addr );
+
+	netdev->header_ops->create( skb, netdev, ETH_P_IEEE802154, &dst_addr, &source_addr, hlen + tlen + size);
+
+	//Add the mac header to the data
+	memcpy( data, cb, size );
+	data[0] = IEEE802154_CMD_ASSOCIATION_REQ;
+	data[1] = capability_information;
+
+	skb->dev = wpan_dev->netdev;
+	skb->protocol = htons(ETH_P_IEEE802154);
+
+	dev_dbg( logdev, "Data bytes sent out %x, %x\n", data[0], data[1]);
+
+	r = ieee802154_subif_start_xmit( skb, wpan_dev->netdev );
+	if( 0 != r) {
+		goto error;
+	}
+
+	goto out;
 
 error:
 	kfree_skb(skb);
@@ -1602,8 +1707,7 @@ static int nl802154_assoc_req( struct sk_buff *skb, struct genl_info *info )
 	dev_dbg( logdev, "channel_number: %u, channel_page: %u, coord_addr_mode: %u, coord_pan_id: 0x%04x, coord_address: %s, capability_information: 0x%02x, timeout_ms: %u\n",
 		channel_number, channel_page, coord_addr_mode, coord_pan_id, coord_addr_str, capability_information, timeout_ms );
 
-	r = rdev_assoc_req( rdev, wpan_dev, channel_number, channel_page, coord_addr_mode, coord_pan_id, coord_address,
-			capability_information );
+	r = nl802154_assoc_send_assoc_req( &rdev->wpan_phy, wpan_dev, coord_addr_mode, coord_pan_id, coord_address, capability_information );
 	if ( 0 != r ) {
 		dev_err( logdev, "send assoc_req failed (%d)\n", r );
 		goto dereg_listener;

--- a/net/ieee802154/nl802154.c
+++ b/net/ieee802154/nl802154.c
@@ -1442,7 +1442,6 @@ nl802154_assoc_send_empty_data_req(struct wpan_phy *wpan_phy, struct wpan_dev *w
 	data = skb_put(skb, size);
 
 	source_addr.mode = IEEE802154_ADDR_LONG;
-	source_addr.pan_id = IEEE802154_PANID_BROADCAST;
 	source_addr.extended_addr = src_addr;
 
 	dst_addr.mode = addr_mode;
@@ -1507,7 +1506,7 @@ nl802154_assoc_send_assoc_req(struct wpan_phy *wpan_phy, struct wpan_dev *wpan_d
 	netdev = wpan_dev->netdev;
 	logdev = &netdev->dev;
 
-	src_addr = -1;
+	src_addr = wpan_dev->extended_addr;
 
 	memset( &source_addr, 0, sizeof( source_addr ) );
 	memset( &dst_addr, 0, sizeof( dst_addr ) );

--- a/net/ieee802154/nl802154.c
+++ b/net/ieee802154/nl802154.c
@@ -1425,7 +1425,7 @@ nl802154_assoc_send_empty_data_req(struct wpan_phy *wpan_phy, struct wpan_dev *w
 	memset( &source_addr, 0, sizeof( source_addr ) );
 	memset( &dst_addr, 0, sizeof( dst_addr ) );
 
-	hlen = 1 + 2 + 1 + 8 + 2; // Packet Length + Frame Control + Sequence Number + Extended Source Addr for Association Request + Destination PAN ID
+	hlen = 2 + 2 + 1 + 8 + 2; // Packet Length + Frame Control + Sequence Number + Extended Source Addr for Association Request + Destination PAN ID
 	hlen += IEEE802154_ADDR_LONG == addr_mode ? 8 : 2; // Extended or Short Destination address
 	tlen = wpan_dev->netdev->needed_tailroom;
 	size = 1; //Todo: Replace magic number. Comes from ieee std 802154 "Association Request Frame Format" with a define
@@ -1513,7 +1513,7 @@ nl802154_assoc_send_assoc_req(struct wpan_phy *wpan_phy, struct wpan_dev *wpan_d
 	memset( &dst_addr, 0, sizeof( dst_addr ) );
 
 	//Create beacon frame / payload
-	hlen = 1 + 2 + 1 + 8 + 2 + 2; // Packet Length + Frame Control + Sequence Number + Extended Source Addr for Association Request + Source PAN ID + Dest PAN ID
+	hlen = 2 + 2 + 1 + 8 + 2 + 2; // Packet Length + Frame Control + Sequence Number + Extended Source Addr for Association Request + Source PAN ID + Dest PAN ID
 	hlen += IEEE802154_ADDR_LONG == addr_mode ? 8 : 2; // Extended or Short Destination address
 	tlen = wpan_dev->netdev->needed_tailroom;
 	size = 2; //Todo: Replace magic number. Comes from ieee std 802154 "Association Request Frame Format" with a define

--- a/net/ieee802154/rdev-ops.h
+++ b/net/ieee802154/rdev-ops.h
@@ -254,20 +254,6 @@ rdev_ed_scan(struct cfg802154_registered_device *rdev, struct wpan_dev *wpan_dev
 }
 
 static inline int
-rdev_assoc_req(struct cfg802154_registered_device *rdev, struct wpan_dev *wpan_dev,
-				u8 channel_number, u8 channel_page, u8 coord_addr_mode, u16 coord_pan_id, u64 coord_address,
-				u8 capability_information )
-{
-	int ret = 0;
-
-	ret = rdev->ops->assoc_req( &rdev->wpan_phy, wpan_dev,
-		coord_addr_mode, coord_pan_id, coord_address,
-		capability_information );
-
-	return ret;
-}
-
-static inline int
 rdev_register_assoc_req_listener(struct cfg802154_registered_device *rdev,
 		struct wpan_dev *wpan_dev,
 		void (*callback)(struct sk_buff *skb, void *arg), void *arg)

--- a/net/ieee802154/rdev-ops.h
+++ b/net/ieee802154/rdev-ops.h
@@ -285,7 +285,7 @@ rdev_deregister_assoc_req_listener( struct cfg802154_registered_device *rdev,
 		struct wpan_dev *wpan_dev,
 		void (*callback)(struct sk_buff *skb, void *arg), void *arg)
 {
-	rdev->ops->deregister_disassoc_req_listener( &rdev->wpan_phy, wpan_dev, callback, arg );
+	rdev->ops->deregister_assoc_req_listener( &rdev->wpan_phy, wpan_dev, callback, arg );
 }
 
 static inline int

--- a/net/mac802154/cfg.c
+++ b/net/mac802154/cfg.c
@@ -393,7 +393,8 @@ ieee802154_assoc_req(struct wpan_phy *wpan_phy, struct wpan_dev *wpan_dev,
 	memset( &dst_addr, 0, sizeof( dst_addr ) );
 
 	//Create beacon frame / payload
-	hlen = 40; //Todo: Replace magic number. comes from ieee std 802154, this value is the max header length.
+	hlen = 4 + 8 + 3; // Frame Control + Sequence Number + Extended Source Addr for Association Request
+	hlen += IEEE802154_ADDR_LONG == addr_mode ? 8 : 2; // Extended or Short Destination address
 	tlen = wpan_dev->netdev->needed_tailroom;
 	size = 2; //Todo: Replace magic number. Comes from ieee std 802154 "Association Request Frame Format" with a define
 
@@ -436,6 +437,8 @@ ieee802154_assoc_req(struct wpan_phy *wpan_phy, struct wpan_dev *wpan_dev,
 
 	cb->source = source_addr;
 	cb->dest = dst_addr;
+
+	//No security fields in yet.
 
 	dev_dbg( logdev, "DSN value in wpan_dev: %p\n", &wpan_dev->dsn);
 

--- a/net/mac802154/cfg.c
+++ b/net/mac802154/cfg.c
@@ -393,7 +393,7 @@ ieee802154_assoc_req(struct wpan_phy *wpan_phy, struct wpan_dev *wpan_dev,
 	memset( &dst_addr, 0, sizeof( dst_addr ) );
 
 	//Create beacon frame / payload
-	hlen = 18;
+	hlen = 40; //Todo: Replace magic number. comes from ieee std 802154, this value is the max header length.
 	tlen = wpan_dev->netdev->needed_tailroom;
 	size = 2; //Todo: Replace magic number. Comes from ieee std 802154 "Association Request Frame Format" with a define
 

--- a/net/mac802154/iface.c
+++ b/net/mac802154/iface.c
@@ -372,6 +372,7 @@ static int mac802154_header_create(struct sk_buff *skb,
 	hdr.fc.type = cb->type;
 	hdr.fc.security_enabled = cb->secen;
 	hdr.fc.ack_request = cb->ackreq;
+	hdr.fc.intra_pan = cb->intra_pan;
 	hdr.seq = atomic_inc_return(&dev->ieee802154_ptr->dsn) & 0xFF;
 
 	if (mac802154_set_header_security(sdata, &hdr, cb) < 0)


### PR DESCRIPTION
-Fixed all issues with skb_push causing a kernel panic by dynamically calculating a proper header length.

-Fixed issue with not properly setting the source extended address for when sending out frames over the air

-Moved iee802154_assoc_req in cfg.c to nl802154_assoc_send_assoc_req in nl802154.c as a static function

-Fixed issue with not deregistering the association request listener properly

-Fixed issue with not setting the intra pan/pan compression bit in the frame control header