### PR TITLE
This sets the short address according to iwpan dev wpan0 info

### DIFF
--- a/net/ieee802154/nl802154.c
+++ b/net/ieee802154/nl802154.c
@@ -1324,12 +1324,11 @@ static void nl802154_assoc_cnf( struct genl_info *info, u16 assoc_short_address,
 
 	r = 0;
 	rdev = info->user_ptr[0];
-	wpan_dev = (struct wpan_dev *) &rdev->wpan_phy.dev;
-	dev = (struct net_device *) wpan_dev->netdev;
-
+	dev = info->user_ptr[1];
+	wpan_dev = dev->ieee802154_ptr;
 	r = rdev_set_short_addr( rdev, wpan_dev, assoc_short_address );
 	if ( 0 != r ) {
-		dev_err( &dev->dev, "nla_put_failure (%d)\n", r );
+		dev_err( &dev->dev, "set short addr failure (%d)\n", r );
 		goto out;
     }
     reply = nlmsg_new( NLMSG_DEFAULT_SIZE, GFP_KERNEL );

--- a/net/ieee802154/nl802154.c
+++ b/net/ieee802154/nl802154.c
@@ -1696,6 +1696,12 @@ static int nl802154_assoc_req( struct sk_buff *skb, struct genl_info *info )
 		goto free_wrk;
 	}
 
+	rdev_set_pan_id(rdev, wpan_dev, coord_pan_id);
+	if ( 0 != r ) {
+		dev_err( logdev, "rdev_set_pan_id failed (%d)\n", r );
+		goto free_wrk;
+	}
+
 	r = rdev_register_assoc_req_listener( rdev, NULL, nl802154_assoc_req_complete, &wrk->work.work );
 	if ( 0 != r ) {
 		dev_err( logdev, "register assoc_req listener failed (%d)\n", r );


### PR DESCRIPTION
this sets the short address properly. 

localhost ~ # iwpan dev wpan0 set short_addr 0     
localhost ~ # iwpan dev wpan0 set pan_id 0x1c56
localhost ~ # ifconfig wpan0 up
localhost ~ # iwpan dev wpan0 set assoc 17 0 0x1c56 0 140 1000
short_address: 0xffff, status: 2
localhost ~ # iwpan dev wpan0 set assoc 17 0 0x1c56 0 140 1000
short_address: 0x5538, status: 0
localhost ~ # iwpan dev wpan0 info
Interface wpan0
	ifindex 4
	wpan_dev 0x1
	extended_addr 0x7aa06baf485708fb
	short_addr 0x5538
	pan_id 0x1c56
	type node
	max_frame_retries -1
	min_be 3
	max_be 5
	max_csma_backoffs 4
	lbt 0