### PR TITLE
set association successfully sets the pan ID on properly now

### DIFF
--- a/net/ieee802154/nl802154.c
+++ b/net/ieee802154/nl802154.c
@@ -1696,11 +1696,15 @@ static int nl802154_assoc_req( struct sk_buff *skb, struct genl_info *info )
 		goto free_wrk;
 	}
 
-	rdev_set_pan_id(rdev, wpan_dev, coord_pan_id);
+	netdev->netdev_ops->ndo_stop(netdev);
+
+	r = rdev_set_pan_id(rdev, wpan_dev, coord_pan_id);
 	if ( 0 != r ) {
 		dev_err( logdev, "rdev_set_pan_id failed (%d)\n", r );
 		goto free_wrk;
 	}
+
+	netdev->netdev_ops->ndo_open(netdev);
 
 	r = rdev_register_assoc_req_listener( rdev, NULL, nl802154_assoc_req_complete, &wrk->work.work );
 	if ( 0 != r ) {

--- a/net/ieee802154/nl802154.c
+++ b/net/ieee802154/nl802154.c
@@ -1326,11 +1326,18 @@ static void nl802154_assoc_cnf( struct genl_info *info, u16 assoc_short_address,
 	rdev = info->user_ptr[0];
 	dev = info->user_ptr[1];
 	wpan_dev = dev->ieee802154_ptr;
+
+	dev->netdev_ops->ndo_open(dev);
+	dev->netdev_ops->ndo_stop(dev);
+
 	r = rdev_set_short_addr( rdev, wpan_dev, assoc_short_address );
 	if ( 0 != r ) {
 		dev_err( &dev->dev, "set short addr failure (%d)\n", r );
 		goto out;
     }
+
+	dev->netdev_ops->ndo_open(dev);
+
     reply = nlmsg_new( NLMSG_DEFAULT_SIZE, GFP_KERNEL );
     if ( NULL == reply ) {
         r = -ENOMEM;


### PR DESCRIPTION
do not need to set pan id before ifconfig wpan0 up now!

thomasy@Thomas-MacBook-Pro:~/workspace/wpan-tools$ ssh root@192.168.2.130
localhost ~ # ifconfig wpan0 up  
localhost ~ # iwpan dev wpan0 set assoc 17 0 0x1c56 0 140 1000
short_address: 0xd21d, status: 0
localhost ~ # iwpan dev wpan0 info
Interface wpan0
	ifindex 4
	wpan_dev 0x1
	extended_addr 0xe295863590a0fe46
	short_addr 0xd21d
	pan_id 0x1c56
	type node
	max_frame_retries -1
	min_be 3
	max_be 5
	max_csma_backoffs 4
	lbt 0
localhost ~ # 