### PR TITLE
Made corrections and additions found necessary while doing network discovery

### DIFF
--- a/include/net/nl802154.h
+++ b/include/net/nl802154.h
@@ -320,7 +320,7 @@ struct ieee802154_beacon_indication {
 	struct {
 		u8 src_addr_mode;          /* enumeration:  SHORT_ADDR, EXTENDED_ADDR   */
 		u16 src_pan_id;            /* Integer    :  0x0000 -- 0xffff            */
-		u32 src_addr;              /* type?      :  range ?                     */
+		u64 src_addr;              /* type?      :  range ?                     */
 		u8 channel_num;            /* integer    :  11 - 27?                    */
 		u8 channel_page;           /* integer    :  range ?                     */
 		u8 superframe_spec;        /* bitfield   :                              */


### PR DESCRIPTION
While doing the network discovery I noticed that information for parsing the beacon at the network level was missing. The problem was that the IEEE802154 standard says that only a list of Pan Descriptors is returned from an active scan, which does not include the beacon payload needed for network level beacon parsing. Re-reading the Zigbee standard, during an Active Scan the Beacon-indications are sent up to the network layer. This is fixed by adding the rest of the Beacon Indication fields to the pan descriptor netlink message sent by the active scan listener. ( the most important being the beacon payload ). I also changed the source address being sent back to be u64 instead of u32.